### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,7 +6,7 @@ Indentation: 2
 JuliaMinVersion: '1.6'
 License: MIT
 PackageName: BestieMinimum
-PackageOwner: abelsiqueira
+PackageOwner: JuliaBesties
 PackageUUID: 911d942b-976d-5ead-b2b6-c499ef4f1d7c
 _commit: v0.8.0
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # BestieMinimum
 
-[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://abelsiqueira.github.io/BestieMinimum.jl/stable)
-[![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://abelsiqueira.github.io/BestieMinimum.jl/dev)
-[![Build Status](https://github.com/abelsiqueira/BestieMinimum.jl/workflows/Test/badge.svg)](https://github.com/abelsiqueira/BestieMinimum.jl/actions)
-[![Test workflow status](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Lint workflow Status](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Lint.yml?query=branch%3Amain)
-[![Docs workflow Status](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/abelsiqueira/BestieMinimum.jl/actions/workflows/Docs.yml?query=branch%3Amain)
+[![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaBesties.github.io/BestieMinimum.jl/stable)
+[![In development documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaBesties.github.io/BestieMinimum.jl/dev)
+[![Build Status](https://github.com/JuliaBesties/BestieMinimum.jl/workflows/Test/badge.svg)](https://github.com/JuliaBesties/BestieMinimum.jl/actions)
+[![Test workflow status](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Lint workflow Status](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Lint.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Lint.yml?query=branch%3Amain)
+[![Docs workflow Status](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Docs.yml/badge.svg?branch=main)](https://github.com/JuliaBesties/BestieMinimum.jl/actions/workflows/Docs.yml?query=branch%3Amain)
 
-[![Coverage](https://codecov.io/gh/abelsiqueira/BestieMinimum.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/abelsiqueira/BestieMinimum.jl)
+[![Coverage](https://codecov.io/gh/JuliaBesties/BestieMinimum.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaBesties/BestieMinimum.jl)
 [![DOI](https://zenodo.org/badge/DOI/FIXME)](https://doi.org/FIXME)
 
 
 
 ## How to Cite
 
-If you use BestieMinimum.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/abelsiqueira/BestieMinimum.jl/blob/main/CITATION.cff).
+If you use BestieMinimum.jl in your work, please cite using the reference given in [CITATION.cff](https://github.com/JuliaBesties/BestieMinimum.jl/blob/main/CITATION.cff).
 
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,11 +18,11 @@ makedocs(;
   doctest = true,
   linkcheck = false, # Rely on Lint.yml/lychee for the links
   authors = "Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors",
-  repo = "https://github.com/abelsiqueira/BestieMinimum.jl/blob/{commit}{path}#{line}",
+  repo = "https://github.com/JuliaBesties/BestieMinimum.jl/blob/{commit}{path}#{line}",
   sitename = "BestieMinimum.jl",
   format = Documenter.HTML(;
     prettyurls = true,
-    canonical = "https://abelsiqueira.github.io/BestieMinimum.jl",
+    canonical = "https://JuliaBesties.github.io/BestieMinimum.jl",
     assets = ["assets/style.css"],
   ),
   pages = [
@@ -34,4 +34,4 @@ makedocs(;
   ],
 )
 
-deploydocs(; repo = "github.com/abelsiqueira/BestieMinimum.jl", push_preview = true)
+deploydocs(; repo = "github.com/JuliaBesties/BestieMinimum.jl", push_preview = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,6 @@ CurrentModule = BestieMinimum
 
 # BestieMinimum
 
-Documentation for [BestieMinimum](https://github.com/abelsiqueira/BestieMinimum.jl).
+Documentation for [BestieMinimum](https://github.com/JuliaBesties/BestieMinimum.jl).
 
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,7 +2,7 @@ exclude = [
   "@ref",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
-  "^https://abelsiqueira.github.io/BestieMinimum.jl/stable$",
+  "^https://JuliaBesties.github.io/BestieMinimum.jl/stable$",
   "zenodo.org/badge/DOI/FIXME$"
 ]
 


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
